### PR TITLE
Replace native alert/confirm with a polished modal

### DIFF
--- a/e2e/tests/nutrition-tracking.spec.ts
+++ b/e2e/tests/nutrition-tracking.spec.ts
@@ -195,9 +195,10 @@ test.describe('Nutrition Tracking', () => {
       .locator('[class*="mealCard"]', { hasText: 'Dinner - Pasta' })
       .first();
 
-    // Handle the confirm dialog
-    page.on('dialog', (dialog) => dialog.accept());
     await mealCardForDelete.getByRole('button', { name: 'Delete meal' }).click();
+
+    // Confirm in the modal
+    await page.getByRole('button', { name: 'Delete', exact: true }).click();
 
     // Verify meal is removed
     await expect(page.getByText('Dinner - Pasta')).not.toBeVisible({ timeout: 5000 });

--- a/src/components/ListView.test.tsx
+++ b/src/components/ListView.test.tsx
@@ -453,11 +453,11 @@ describe('ListView', () => {
     const deleteButtons = screen.getAllByTitle('Delete workout');
     expect(deleteButtons.length).toBe(2);
 
-    // Click the first delete button
+    // Click the first delete button — opens the confirm modal
     fireEvent.click(deleteButtons[0]);
 
-    // Check that confirm was called
-    expect(window.confirm).toHaveBeenCalledWith('Are you sure you want to delete this workout?');
+    // Confirm in the modal
+    fireEvent.click(await screen.findByRole('button', { name: 'Delete' }));
 
     // Check that the workout was removed from the list
     await waitFor(() => {
@@ -492,11 +492,11 @@ describe('ListView', () => {
     const deleteButtons = screen.getAllByTitle('Delete pain score');
     expect(deleteButtons.length).toBe(2);
 
-    // Click the first delete button
+    // Click the first delete button — opens the confirm modal
     fireEvent.click(deleteButtons[0]);
 
-    // Check that confirm was called
-    expect(window.confirm).toHaveBeenCalledWith('Are you sure you want to delete this pain score?');
+    // Confirm in the modal
+    fireEvent.click(await screen.findByRole('button', { name: 'Delete' }));
 
     // Check that the pain score was removed from the list
     await waitFor(() => {
@@ -509,10 +509,6 @@ describe('ListView', () => {
     // Mock console.error
     const originalConsoleError = console.error;
     console.error = vi.fn();
-
-    // Mock window.alert
-    const originalAlert = window.alert;
-    window.alert = vi.fn();
 
     // Mock timeline data and failed deletion
     server.use(
@@ -538,28 +534,26 @@ describe('ListView', () => {
     // Find delete buttons for workouts
     const deleteButtons = screen.getAllByTitle('Delete workout');
 
-    // Click the first delete button
+    // Click the first delete button, then confirm in the modal
     fireEvent.click(deleteButtons[0]);
+    fireEvent.click(await screen.findByRole('button', { name: 'Delete' }));
 
-    // Check that the error was handled
+    // Check that the error was handled and surfaced via the alert modal
     await waitFor(() => {
       expect(console.error).toHaveBeenCalledWith('Failed to delete workout:', expect.any(Error));
-      expect(window.alert).toHaveBeenCalledWith('Failed to delete workout. Please try again.');
     });
+    expect(
+      await screen.findByText('Failed to delete workout. Please try again.')
+    ).toBeInTheDocument();
 
     // Restore mocks
     console.error = originalConsoleError;
-    window.alert = originalAlert;
   });
 
   it('handles pain score deletion error', async () => {
     // Mock console.error
     const originalConsoleError = console.error;
     console.error = vi.fn();
-
-    // Mock window.alert
-    const originalAlert = window.alert;
-    window.alert = vi.fn();
 
     // Mock timeline data and failed deletion
     server.use(
@@ -585,24 +579,23 @@ describe('ListView', () => {
     // Find delete buttons for pain scores
     const deleteButtons = screen.getAllByTitle('Delete pain score');
 
-    // Click the first delete button
+    // Click the first delete button, then confirm in the modal
     fireEvent.click(deleteButtons[0]);
+    fireEvent.click(await screen.findByRole('button', { name: 'Delete' }));
 
-    // Check that the error was handled
+    // Check that the error was handled and surfaced via the alert modal
     await waitFor(() => {
       expect(console.error).toHaveBeenCalledWith('Failed to delete pain score:', expect.any(Error));
-      expect(window.alert).toHaveBeenCalledWith('Failed to delete pain score. Please try again.');
     });
+    expect(
+      await screen.findByText('Failed to delete pain score. Please try again.')
+    ).toBeInTheDocument();
 
     // Restore mocks
     console.error = originalConsoleError;
-    window.alert = originalAlert;
   });
 
   it('does not delete when user cancels confirmation', async () => {
-    // Override the mock to return false (user clicked "Cancel")
-    (window.confirm as ReturnType<typeof vi.fn>).mockReturnValue(false);
-
     server.use(
       http.get('/api/activity', () => {
         return HttpResponse.json(mockActivityData);
@@ -624,15 +617,15 @@ describe('ListView', () => {
     const deleteButtons = screen.getAllByTitle('Delete workout');
     const initialCount = deleteButtons.length;
 
-    // Click the first delete button
+    // Click the first delete button, then cancel in the modal
     fireEvent.click(deleteButtons[0]);
+    fireEvent.click(await screen.findByRole('button', { name: 'Cancel' }));
 
-    // Check that confirm was called
-    expect(window.confirm).toHaveBeenCalledWith('Are you sure you want to delete this workout?');
-
-    // Check that the workout count hasn't changed
-    const stillDeleteButtons = screen.getAllByTitle('Delete workout');
-    expect(stillDeleteButtons.length).toBe(initialCount);
+    // Modal closes and the workout count hasn't changed
+    await waitFor(() => {
+      expect(screen.queryByRole('button', { name: 'Delete' })).not.toBeInTheDocument();
+    });
+    expect(screen.getAllByTitle('Delete workout').length).toBe(initialCount);
   });
 
   it('displays filter controls', async () => {

--- a/src/components/ListView.tsx
+++ b/src/components/ListView.tsx
@@ -19,6 +19,7 @@ import { Card } from './ui/Card';
 import { listViewReducer, createInitialListViewState } from './listView.reducer';
 import { formatWeightWithKg } from '../utils/weight';
 import { Badge } from './ui/Badge';
+import { useConfirm } from './ui/useConfirm';
 import { getPainSeverityColor, getSleepSeverityColor } from '../styles/chartColors';
 
 export const ListView = () => {
@@ -39,6 +40,7 @@ export const ListView = () => {
   } = state;
 
   const fabRef = useRef<HTMLDivElement | null>(null);
+  const { confirm, alert, dialog } = useConfirm();
 
   // Fetch data on mount
   useEffect(() => {
@@ -156,47 +158,71 @@ export const ListView = () => {
   };
 
   const handleDeleteWorkout = async (workoutId: number) => {
-    if (window.confirm('Are you sure you want to delete this workout?')) {
-      try {
-        dispatch({ type: 'SET_DELETING', payload: { type: 'workout', id: workoutId } });
-        await deleteWorkout(workoutId);
-        handleWorkoutDeleted(workoutId);
-      } catch (err) {
-        console.error('Failed to delete workout:', err);
-        alert('Failed to delete workout. Please try again.');
-      } finally {
-        dispatch({ type: 'SET_DELETING', payload: null });
-      }
+    const confirmed = await confirm({
+      title: 'Delete workout?',
+      message: 'This will permanently remove this workout. This can’t be undone.',
+      confirmText: 'Delete',
+      variant: 'danger',
+    });
+    if (!confirmed) return;
+    try {
+      dispatch({ type: 'SET_DELETING', payload: { type: 'workout', id: workoutId } });
+      await deleteWorkout(workoutId);
+      handleWorkoutDeleted(workoutId);
+    } catch (err) {
+      console.error('Failed to delete workout:', err);
+      await alert({
+        title: 'Delete failed',
+        message: 'Failed to delete workout. Please try again.',
+      });
+    } finally {
+      dispatch({ type: 'SET_DELETING', payload: null });
     }
   };
 
   const handleDeletePainScore = async (painScoreId: number) => {
-    if (window.confirm('Are you sure you want to delete this pain score?')) {
-      try {
-        dispatch({ type: 'SET_DELETING', payload: { type: 'painScore', id: painScoreId } });
-        await deletePainScore(painScoreId);
-        handlePainScoreDeleted(painScoreId);
-      } catch (err) {
-        console.error('Failed to delete pain score:', err);
-        alert('Failed to delete pain score. Please try again.');
-      } finally {
-        dispatch({ type: 'SET_DELETING', payload: null });
-      }
+    const confirmed = await confirm({
+      title: 'Delete pain score?',
+      message: 'This will permanently remove this pain score.',
+      confirmText: 'Delete',
+      variant: 'danger',
+    });
+    if (!confirmed) return;
+    try {
+      dispatch({ type: 'SET_DELETING', payload: { type: 'painScore', id: painScoreId } });
+      await deletePainScore(painScoreId);
+      handlePainScoreDeleted(painScoreId);
+    } catch (err) {
+      console.error('Failed to delete pain score:', err);
+      await alert({
+        title: 'Delete failed',
+        message: 'Failed to delete pain score. Please try again.',
+      });
+    } finally {
+      dispatch({ type: 'SET_DELETING', payload: null });
     }
   };
 
   const handleDeleteSleepScore = async (sleepScoreId: number) => {
-    if (window.confirm('Are you sure you want to delete this sleep score?')) {
-      try {
-        dispatch({ type: 'SET_DELETING', payload: { type: 'sleepScore', id: sleepScoreId } });
-        await deleteSleepScore(sleepScoreId);
-        handleSleepScoreDeleted(sleepScoreId);
-      } catch (err) {
-        console.error('Failed to delete sleep score:', err);
-        alert('Failed to delete sleep score. Please try again.');
-      } finally {
-        dispatch({ type: 'SET_DELETING', payload: null });
-      }
+    const confirmed = await confirm({
+      title: 'Delete sleep score?',
+      message: 'This will permanently remove this sleep score.',
+      confirmText: 'Delete',
+      variant: 'danger',
+    });
+    if (!confirmed) return;
+    try {
+      dispatch({ type: 'SET_DELETING', payload: { type: 'sleepScore', id: sleepScoreId } });
+      await deleteSleepScore(sleepScoreId);
+      handleSleepScoreDeleted(sleepScoreId);
+    } catch (err) {
+      console.error('Failed to delete sleep score:', err);
+      await alert({
+        title: 'Delete failed',
+        message: 'Failed to delete sleep score. Please try again.',
+      });
+    } finally {
+      dispatch({ type: 'SET_DELETING', payload: null });
     }
   };
 
@@ -483,6 +509,7 @@ export const ListView = () => {
           </div>
         )}
       </div>
+      {dialog}
     </div>
   );
 };

--- a/src/components/ui/Button.module.css
+++ b/src/components/ui/Button.module.css
@@ -103,6 +103,19 @@
   text-decoration: none;
 }
 
+.dangerSolid {
+  background: var(--color-danger);
+  color: #fff;
+  border-color: var(--color-danger);
+  box-shadow: 0 1px 2px rgba(165, 52, 43, 0.35);
+}
+.dangerSolid:hover {
+  background: #c33b30;
+  border-color: #c33b30;
+  color: #fff;
+  text-decoration: none;
+}
+
 /* ---- Disabled ---- */
 .btn:disabled {
   background: var(--color-surface-2);

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -3,7 +3,7 @@ import { Link } from 'wouter';
 import classNames from 'classnames';
 import styles from './Button.module.css';
 
-export type ButtonVariant = 'primary' | 'secondary' | 'tertiary' | 'danger';
+export type ButtonVariant = 'primary' | 'secondary' | 'tertiary' | 'danger' | 'dangerSolid';
 export type ButtonSize = 'sm' | 'md' | 'lg';
 
 interface CommonProps {

--- a/src/components/ui/ConfirmDialog.module.css
+++ b/src/components/ui/ConfirmDialog.module.css
@@ -1,0 +1,28 @@
+.title {
+  margin: 0 0 8px;
+  font-family: var(--font-display);
+  font-size: 1.25rem;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  color: var(--color-ink);
+}
+
+.message {
+  margin: 0;
+  color: var(--color-text-muted);
+  font-size: 0.95rem;
+  line-height: 1.5;
+}
+
+.actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+  margin-top: 24px;
+}
+
+@media (max-width: 480px) {
+  .actions {
+    flex-direction: column-reverse;
+  }
+}

--- a/src/components/ui/Modal.module.css
+++ b/src/components/ui/Modal.module.css
@@ -1,0 +1,48 @@
+.overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 2000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
+  background: rgba(16, 32, 28, 0.45);
+  animation: overlayIn 0.15s ease;
+}
+
+.panel {
+  width: 100%;
+  max-width: 420px;
+  background: var(--color-surface);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-3);
+  padding: 24px;
+  animation: panelIn 0.16s ease;
+}
+
+@keyframes overlayIn {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes panelIn {
+  from {
+    opacity: 0;
+    transform: translateY(8px) scale(0.98);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .overlay,
+  .panel {
+    animation: none;
+  }
+}

--- a/src/components/ui/Modal.tsx
+++ b/src/components/ui/Modal.tsx
@@ -1,0 +1,65 @@
+import React, { useEffect, useRef } from 'react';
+import { createPortal } from 'react-dom';
+import styles from './Modal.module.css';
+
+interface ModalProps {
+  /** Called when the user dismisses via backdrop click or Escape. */
+  onClose: () => void;
+  /** id of the element labelling the dialog (for aria-labelledby). */
+  labelId?: string;
+  role?: 'dialog' | 'alertdialog';
+  children: React.ReactNode;
+}
+
+/**
+ * Accessible modal shell: portals to <body>, dims the page, traps initial
+ * focus, and closes on Escape / backdrop click. Rendering it opens it.
+ */
+export function Modal({ onClose, labelId, role = 'dialog', children }: ModalProps) {
+  const panelRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const previouslyFocused = document.activeElement as HTMLElement | null;
+
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    document.addEventListener('keydown', onKey);
+
+    // Move focus into the dialog (first focusable element).
+    const focusable = panelRef.current?.querySelector<HTMLElement>(
+      'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+    );
+    focusable?.focus();
+
+    return () => {
+      document.removeEventListener('keydown', onKey);
+      previouslyFocused?.focus?.();
+    };
+  }, [onClose]);
+
+  return createPortal(
+    // Backdrop: click-to-dismiss is a convenience; keyboard users dismiss with
+    // Escape (handled above), so the backdrop itself is presentational.
+    // eslint-disable-next-line jsx-a11y/no-static-element-interactions
+    <div
+      className={styles.overlay}
+      onMouseDown={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      <div
+        ref={panelRef}
+        className={styles.panel}
+        role={role}
+        aria-modal="true"
+        aria-labelledby={labelId}
+      >
+        {children}
+      </div>
+    </div>,
+    document.body
+  );
+}
+
+export default Modal;

--- a/src/components/ui/useConfirm.tsx
+++ b/src/components/ui/useConfirm.tsx
@@ -1,0 +1,93 @@
+import React, { useCallback, useId, useState } from 'react';
+import { Modal } from './Modal';
+import { Button } from './Button';
+import styles from './ConfirmDialog.module.css';
+
+interface ConfirmOptions {
+  title?: string;
+  message: React.ReactNode;
+  confirmText?: string;
+  cancelText?: string;
+  /** 'danger' renders a solid red confirm button for destructive actions. */
+  variant?: 'primary' | 'danger';
+}
+
+interface AlertOptions {
+  title?: string;
+  message: React.ReactNode;
+  okText?: string;
+}
+
+type Request =
+  | { kind: 'confirm'; options: ConfirmOptions; resolve: (value: boolean) => void }
+  | { kind: 'alert'; options: AlertOptions; resolve: () => void };
+
+/**
+ * Promise-based replacement for window.confirm / window.alert, rendered with
+ * the app's polished <Modal>. Returns `confirm`, `alert`, and the `dialog`
+ * node to render somewhere in the component's output.
+ *
+ *   const { confirm, alert, dialog } = useConfirm();
+ *   if (await confirm({ message: 'Delete this?', variant: 'danger' })) { ... }
+ *   return <div>...{dialog}</div>;
+ */
+export function useConfirm() {
+  const [request, setRequest] = useState<Request | null>(null);
+  const labelId = useId();
+
+  const confirm = useCallback(
+    (options: ConfirmOptions) =>
+      new Promise<boolean>((resolve) => setRequest({ kind: 'confirm', options, resolve })),
+    []
+  );
+
+  const alert = useCallback(
+    (options: AlertOptions) =>
+      new Promise<void>((resolve) => setRequest({ kind: 'alert', options, resolve })),
+    []
+  );
+
+  let dialog: React.ReactNode = null;
+  if (request) {
+    const finish = (confirmed: boolean) => {
+      if (request.kind === 'confirm') request.resolve(confirmed);
+      else request.resolve();
+      setRequest(null);
+    };
+    const { title, message } = request.options;
+
+    dialog = (
+      <Modal onClose={() => finish(false)} labelId={title ? labelId : undefined} role="alertdialog">
+        {title && (
+          <h2 id={labelId} className={styles.title}>
+            {title}
+          </h2>
+        )}
+        <div className={styles.message}>{message}</div>
+        <div className={styles.actions}>
+          {request.kind === 'confirm' ? (
+            <>
+              <Button variant="secondary" onClick={() => finish(false)}>
+                {request.options.cancelText ?? 'Cancel'}
+              </Button>
+              <Button
+                variant={request.options.variant === 'danger' ? 'dangerSolid' : 'primary'}
+                onClick={() => finish(true)}
+              >
+                {request.options.confirmText ?? 'Confirm'}
+              </Button>
+            </>
+          ) : (
+            <Button variant="primary" onClick={() => finish(false)}>
+              {request.options.okText ?? 'OK'}
+            </Button>
+          )}
+        </div>
+      </Modal>
+    );
+  }
+
+  return { confirm, alert, dialog };
+}
+
+export default useConfirm;

--- a/src/pages/NutritionPage.tsx
+++ b/src/pages/NutritionPage.tsx
@@ -15,6 +15,7 @@ import { MdOutlineEdit } from 'react-icons/md';
 import styles from './NutritionPage.module.css';
 import { PageHeader } from '../components/ui/PageHeader';
 import { Button } from '../components/ui/Button';
+import { useConfirm } from '../components/ui/useConfirm';
 
 function NutritionPage(): React.ReactElement {
   const [, setLocation] = useLocation();
@@ -28,6 +29,7 @@ function NutritionPage(): React.ReactElement {
   const [weightInput, setWeightInput] = useState<string>('');
   const [weightError, setWeightError] = useState<string | null>(null);
   const [savingWeight, setSavingWeight] = useState<boolean>(false);
+  const { confirm, dialog } = useConfirm();
 
   useEffect(() => {
     const loadData = async () => {
@@ -75,9 +77,13 @@ function NutritionPage(): React.ReactElement {
   };
 
   const handleDeleteMeal = async (mealId: number) => {
-    if (!window.confirm('Are you sure you want to delete this meal?')) {
-      return;
-    }
+    const confirmed = await confirm({
+      title: 'Delete meal?',
+      message: 'This will remove the meal from this day.',
+      confirmText: 'Delete',
+      variant: 'danger',
+    });
+    if (!confirmed) return;
 
     try {
       await deleteMeal(mealId);
@@ -309,6 +315,7 @@ function NutritionPage(): React.ReactElement {
           </div>
         </div>
       </div>
+      {dialog}
     </div>
   );
 }

--- a/src/pages/WorkoutShowPage.tsx
+++ b/src/pages/WorkoutShowPage.tsx
@@ -10,6 +10,7 @@ import { toHomePath, toWorkoutEditPath, toExerciseProgressionPath } from '../uti
 import { formatWeightWithKg } from '../utils/weight';
 import { Badge } from '../components/ui/Badge';
 import { Button } from '../components/ui/Button';
+import { useConfirm } from '../components/ui/useConfirm';
 
 const WorkoutShowPage: React.FC = () => {
   const { id } = useParams<{ id: string }>();
@@ -20,6 +21,7 @@ const WorkoutShowPage: React.FC = () => {
   const [loading, setLoading] = useState<boolean>(true);
   const [error, setError] = useState<string | null>(null);
   const [isDeleting, setIsDeleting] = useState<boolean>(false);
+  const { confirm, alert, dialog } = useConfirm();
 
   useEffect(() => {
     const loadWorkout = async () => {
@@ -40,16 +42,25 @@ const WorkoutShowPage: React.FC = () => {
   }, [workoutId]);
 
   const handleDelete = async () => {
-    if (window.confirm('Are you sure you want to delete this workout?')) {
-      try {
-        setIsDeleting(true);
-        await deleteWorkout(workoutId);
-        setLocation('/');
-      } catch (err) {
-        console.error('Failed to delete workout:', err);
-        alert('Failed to delete workout. Please try again.');
-        setIsDeleting(false);
-      }
+    const confirmed = await confirm({
+      title: 'Delete workout?',
+      message: 'This will permanently remove this workout. This can’t be undone.',
+      confirmText: 'Delete',
+      variant: 'danger',
+    });
+    if (!confirmed) return;
+
+    try {
+      setIsDeleting(true);
+      await deleteWorkout(workoutId);
+      setLocation('/');
+    } catch (err) {
+      console.error('Failed to delete workout:', err);
+      await alert({
+        title: 'Delete failed',
+        message: 'Failed to delete workout. Please try again.',
+      });
+      setIsDeleting(false);
     }
   };
 
@@ -164,6 +175,7 @@ const WorkoutShowPage: React.FC = () => {
           </Button>
         </div>
       </div>
+      {dialog}
     </div>
   );
 };


### PR DESCRIPTION
Add an accessible Modal component (portal, Escape/backdrop dismiss, focus handling, reduced-motion) and a promise-based useConfirm hook exposing confirm()/alert(). Replace window.confirm/window.alert across ListView, WorkoutShowPage, and NutritionPage with themed dialogs (solid-red confirm for destructive actions via a new Button dangerSolid variant).

- Mobile-friendly: panel maxes at 420px with viewport padding; action buttons stack full-width under 480px.
- Update ListView tests to drive the modal; update the nutrition-tracking e2e delete flow to confirm in the modal (drops the native dialog handler).