### PR TITLE
Polish view toggle, delete buttons, and mobile input spacing

### DIFF
--- a/src/components/ListView.module.css
+++ b/src/components/ListView.module.css
@@ -174,38 +174,6 @@
   outline: none;
 }
 
-.deleteBtn {
-  background-color: var(--color-surface);
-  border: 1px solid var(--color-border-strong);
-  color: var(--color-primary);
-  border-radius: var(--radius-sm);
-  width: 32px;
-  height: 32px;
-  font-size: 16px;
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 0;
-}
-
-.deleteBtn:hover {
-  background-color: var(--color-danger-tint);
-  color: var(--color-danger);
-  border-color: var(--color-danger);
-}
-
-.deleteBtn:focus {
-  box-shadow: var(--focus-ring);
-  outline: none;
-}
-
-.deleteBtn:disabled {
-  background: var(--color-surface-2);
-  color: var(--color-text-faint);
-  cursor: not-allowed;
-}
-
 .listCardContent {
   margin-top: 10px;
 }

--- a/src/components/ListView.tsx
+++ b/src/components/ListView.tsx
@@ -305,7 +305,7 @@ export const ListView = () => {
                       </Button>
                       <Button
                         iconOnly
-                        variant="danger"
+                        variant="dangerGhost"
                         onClick={() => handleDeleteWorkout(workout.id)}
                         disabled={isDeleting?.type === 'workout' && isDeleting.id === workout.id}
                         title="Delete workout"
@@ -377,7 +377,7 @@ export const ListView = () => {
                       </Button>
                       <Button
                         iconOnly
-                        variant="danger"
+                        variant="dangerGhost"
                         onClick={() => handleDeletePainScore(painScore.id)}
                         disabled={
                           isDeleting?.type === 'painScore' && isDeleting.id === painScore.id
@@ -432,7 +432,7 @@ export const ListView = () => {
                       </Button>
                       <Button
                         iconOnly
-                        variant="danger"
+                        variant="dangerGhost"
                         onClick={() => handleDeleteSleepScore(sleepScore.id)}
                         disabled={
                           isDeleting?.type === 'sleepScore' && isDeleting.id === sleepScore.id

--- a/src/components/WorkoutForm.module.css
+++ b/src/components/WorkoutForm.module.css
@@ -73,6 +73,11 @@
 /* On narrow screens the toggle beside the input squeezes it; stack the
    unit toggle above the full-width weight input instead. */
 @media (max-width: 640px) {
+  /* Trim the heavy card padding so inputs get room and sit evenly inset. */
+  .workoutForm {
+    padding: 20px;
+  }
+
   .weightInputWrapper {
     flex-direction: column;
     align-items: stretch;

--- a/src/components/WorkoutForm.tsx
+++ b/src/components/WorkoutForm.tsx
@@ -27,6 +27,7 @@ import { GiMuscleUp } from 'react-icons/gi';
 import { IoRepeat } from 'react-icons/io5';
 import { IoMdStopwatch } from 'react-icons/io';
 import { FaWeightHanging, FaTrophy } from 'react-icons/fa';
+import { MdClose } from 'react-icons/md';
 import { Badge } from './ui/Badge';
 
 interface FormValues {
@@ -395,12 +396,13 @@ function WorkoutForm({
                     </div>
                     <Button
                       type="button"
-                      variant="secondary"
+                      variant="dangerGhost"
                       iconOnly
                       onClick={() => remove(index)}
                       title="Remove exercise"
+                      aria-label="Remove exercise"
                     >
-                      x
+                      <MdClose />
                     </Button>
                   </li>
                 ))}

--- a/src/components/ui/Button.module.css
+++ b/src/components/ui/Button.module.css
@@ -103,6 +103,18 @@
   text-decoration: none;
 }
 
+/* Quiet destructive action (icon rows): muted until hover, then danger-red. */
+.dangerGhost {
+  background: transparent;
+  color: var(--color-text-faint);
+  border-color: transparent;
+}
+.dangerGhost:hover {
+  background: var(--color-danger-tint);
+  color: var(--color-danger);
+  text-decoration: none;
+}
+
 .dangerSolid {
   background: var(--color-danger);
   color: #fff;

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -3,7 +3,13 @@ import { Link } from 'wouter';
 import classNames from 'classnames';
 import styles from './Button.module.css';
 
-export type ButtonVariant = 'primary' | 'secondary' | 'tertiary' | 'danger' | 'dangerSolid';
+export type ButtonVariant =
+  | 'primary'
+  | 'secondary'
+  | 'tertiary'
+  | 'danger'
+  | 'dangerSolid'
+  | 'dangerGhost';
 export type ButtonSize = 'sm' | 'md' | 'lg';
 
 interface CommonProps {

--- a/src/components/ui/Field.module.css
+++ b/src/components/ui/Field.module.css
@@ -12,6 +12,9 @@
 
 .control {
   width: 100%;
+  /* Native date/time inputs have an intrinsic min-width and won't shrink
+     without this, overflowing the card's right padding on narrow screens. */
+  min-width: 0;
   box-sizing: border-box;
   padding: 11px 13px;
   border: 1px solid var(--color-border-strong);

--- a/src/pages/NutritionPage.module.css
+++ b/src/pages/NutritionPage.module.css
@@ -113,17 +113,6 @@
   padding: 0;
 }
 
-.deleteBtn {
-  border-radius: var(--radius-sm);
-  width: 32px;
-  height: 32px;
-  font-size: 16px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 0;
-}
-
 .mealMacros {
   display: flex;
   gap: 15px;

--- a/src/pages/NutritionPage.tsx
+++ b/src/pages/NutritionPage.tsx
@@ -215,7 +215,7 @@ function NutritionPage(): React.ReactElement {
                       </Button>
                       <Button
                         iconOnly
-                        variant="secondary"
+                        variant="dangerGhost"
                         onClick={() => handleDeleteMeal(meal.id)}
                         title="Delete meal"
                         aria-label="Delete meal"

--- a/src/pages/TimelinePage.module.css
+++ b/src/pages/TimelinePage.module.css
@@ -5,33 +5,43 @@
   gap: 16px;
 }
 
+/* Segmented toggle — matches the app's unit / multiplier toggle idiom. */
 .viewToggle {
-  display: flex;
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-sm);
-  overflow: hidden;
+  display: inline-flex;
+  background: var(--color-border);
+  border-radius: var(--radius-md);
+  padding: 4px;
+  gap: 2px;
 }
 
 .viewToggle button {
-  padding: 8px 16px;
-  background-color: var(--color-surface);
+  min-width: 72px;
+  height: 36px;
+  padding: 0 16px;
+  background: transparent;
   border: none;
-  cursor: pointer;
+  color: var(--color-text-muted);
+  font-family: inherit;
+  font-weight: 600;
   font-size: 14px;
-  transition: background-color 0.2s;
-}
-
-.viewToggle button:first-child {
-  border-right: 1px solid var(--color-border);
-}
-
-.active {
-  background-color: var(--color-primary) !important;
-  color: white;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  transition: all 0.15s ease;
+  -webkit-tap-highlight-color: transparent;
 }
 
 .viewToggle button:hover:not(.active) {
-  background-color: var(--color-surface-2);
+  color: var(--color-ink);
+}
+
+.viewToggle button:active {
+  transform: scale(0.97);
+}
+
+.active {
+  background: var(--color-surface);
+  color: var(--color-primary);
+  box-shadow: var(--shadow-1);
 }
 
 .button {
@@ -180,19 +190,6 @@
 
 .editBtn:hover {
   color: var(--color-primary-active);
-}
-
-.deleteBtn {
-  background: none;
-  border: none;
-  cursor: pointer;
-  font-size: 0.9rem;
-  padding: 4px 8px;
-  color: var(--color-danger);
-}
-
-.deleteBtn:hover {
-  color: var(--color-danger-ink);
 }
 
 @media (max-width: 768px) {


### PR DESCRIPTION
- Restyle the Calendar/List toggle on the timeline to the app's segmented toggle idiom (surface active tab on a neutral track), matching the unit and meal-multiplier toggles instead of the old solid-fill toggle.
- Add a quiet `dangerGhost` Button variant (muted until hover, danger-red on hover) and use it for every destructive icon action — ListView, Nutrition meals, and the workout Remove-exercise button, which was a bare text "x". Lists are no longer peppered with permanent red X's. Drop the now-dead per-page .deleteBtn CSS.
- Fix native date/time inputs overflowing the card's right padding on narrow screens by adding min-width:0 to the shared Field control, and trim the workout card padding on mobile so inputs sit evenly inset.