### PR TITLE
Fix iOS toggle selection + date input bleeding past the card

### DIFF
--- a/src/components/ui/Field.module.css
+++ b/src/components/ui/Field.module.css
@@ -15,6 +15,7 @@
   /* Native date/time inputs have an intrinsic min-width and won't shrink
      without this, overflowing the card's right padding on narrow screens. */
   min-width: 0;
+  max-width: 100%;
   box-sizing: border-box;
   padding: 11px 13px;
   border: 1px solid var(--color-border-strong);
@@ -43,6 +44,24 @@
 select.control {
   height: 44px;
   cursor: pointer;
+}
+
+/* iOS Safari ignores width/min-width on native date & time inputs and sizes
+   them to their content, so they bleed past the card's right edge. Neutralize
+   the native control on touch devices (iOS still presents its own picker on
+   focus); desktop keeps its calendar dropdown. */
+@media (hover: none) and (pointer: coarse) {
+  input.control[type='date'],
+  input.control[type='time'],
+  input.control[type='datetime-local'] {
+    -webkit-appearance: none;
+    appearance: none;
+  }
+
+  input.control[type='date']::-webkit-date-and-time-value {
+    margin: 0;
+    text-align: left;
+  }
 }
 
 textarea.control {

--- a/src/pages/TimelinePage.module.css
+++ b/src/pages/TimelinePage.module.css
@@ -41,9 +41,12 @@
   transform: scale(0.97);
 }
 
-.active {
+/* Must out-specify `.viewToggle button` (0,1,1) or only the box-shadow lands
+   and the selected tab looks the same grey as the rest. */
+.viewToggle button.active {
   background: var(--color-surface);
   color: var(--color-primary);
+  -webkit-text-fill-color: var(--color-primary);
   box-shadow: var(--shadow-1);
 }
 


### PR DESCRIPTION
## Summary
Fixes two Safari/iOS-specific bugs reported after #88 merged: the Calendar/List toggle showed no visible selection, and native date inputs bled past the card's right edge on iPhone.

## 🐛 Toggle — no visible selection
The selected tab looked the same grey as the unselected one. The `.active` rule lost on **specificity** to the base `.viewToggle button` (0,1,1) selector, so only its uncontested `box-shadow` landed — no white background, no teal text. Scoped the active styles under `.viewToggle button.active` so they win.

This affected **every browser**, not just Safari — the faint shadow just masked it on desktop.

## 🐛 Date input bleeds past the card (iOS)
`width: 100%` + `min-width: 0` isn't enough on iOS: Safari sizes native date/time controls to their content and overflows the card. Added `appearance: none` for `date` / `time` / `datetime-local` inputs **on touch devices only** (`@media (hover: none) and (pointer: coarse)`) so they respect the box model. iOS still presents its own picker on focus, and desktop keeps its calendar dropdown. Also added `max-width: 100%` to the shared control.

## ✅ Verified in real iOS WebKit (iPhone 13 profile)
- Selected tab computes to **teal on white** (`rgb(14,110,94)` / `rgb(255,255,255)`) vs **muted grey** inactive (`rgb(91,107,100)`) — clearly distinct.
- Date input right edge sits **inside** the card (329px vs 350px card edge; was overflowing).
- `tsc`, ESLint, `vite build` clean; 395/395 unit tests pass.

## 📸 Screenshots
Design-review gallery: https://claude.ai/code/artifact/c06ea948-466b-4e17-8c04-7e7a1f1c29eb
